### PR TITLE
Update genericRequest.go - Fix error 200 for list request with APIv2

### DIFF
--- a/request/genericRequest.go
+++ b/request/genericRequest.go
@@ -96,7 +96,7 @@ func GeneriqueCommandV2Get(urlCentreon string, command string, debugV bool) (err
 	if err != nil {
 		return err, []byte{}
 	}
-	if statusCode != 200 && strings.Contains(command, "show") || strings.Contains(command, "list") {
+	if statusCode != 200 && (strings.Contains(command, "show") || strings.Contains(command, "list")) {
 		fmt.Printf(colorRed, "ERROR: ")
 		fmt.Println(statusCode)
 		os.Exit(1)


### PR DESCRIPTION
Add () for the error condition on APIv2 GET Requests, causing `ERROR: 200` with APIv2 requests with lists commands