### PR TITLE
Fix list all on RealtimeService and hosts

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -6,7 +6,7 @@ DARWIN=$(EXECUTABLE)_darwin_amd64
 
 all: clean build ## Build and run tests
 
-build: windows linux darwin ## Build binaries
+build: windows linux darwin linux_woc ## Build binaries
 
 windows: $(WINDOWS) ## Build for Windows
 
@@ -23,7 +23,7 @@ $(LINUX):
 	env GOOS=linux GOARCH=amd64 go build -o $(LINUX)  main.go
 
 $(LINUX_WOC):
-	env CGO_ENABLED=0 GOOS=linux GOARCH=amd64 go build -o $(LINUX)  main.go
+	env CGO_ENABLED=0 GOOS=linux GOARCH=amd64 go build -o $(LINUX_WOC)  main.go
 
 $(DARWIN):
 	env GOOS=darwin GOARCH=amd64 go build -o $(DARWIN)  main.go

--- a/Makefile
+++ b/Makefile
@@ -1,6 +1,7 @@
 EXECUTABLE=centctl
 WINDOWS=$(EXECUTABLE)_windows_amd64.exe
 LINUX=$(EXECUTABLE)_linux_amd64
+LINUX_WOC=$(EXECUTABLE)_linux_woc_amd64
 DARWIN=$(EXECUTABLE)_darwin_amd64
 
 all: clean build ## Build and run tests
@@ -13,14 +14,19 @@ linux: $(LINUX) ## Build for Linux
 
 darwin: $(DARWIN) ## Build for Darwin (macOS)
 
+linux_woc: $(LINUX_WOC) ## Build for Linux without C import (for RHEL7)
+
 $(WINDOWS):
 	env GOOS=windows GOARCH=amd64 go build -o $(WINDOWS)  main.go
 
 $(LINUX):
 	env GOOS=linux GOARCH=amd64 go build -o $(LINUX)  main.go
 
+$(LINUX_WOC):
+	env CGO_ENABLED=0 GOOS=linux GOARCH=amd64 go build -o $(LINUX)  main.go
+
 $(DARWIN):
 	env GOOS=darwin GOARCH=amd64 go build -o $(DARWIN)  main.go
 
 clean: ## Remove previous build
-	rm -f $(WINDOWS) $(LINUX) $(DARWIN)
+	rm -f $(WINDOWS) $(LINUX) $(DARWIN) $(LINUX_WOC)

--- a/cmd/list/realtimeService.go
+++ b/cmd/list/realtimeService.go
@@ -61,7 +61,7 @@ var realtimeServiceCmd = &cobra.Command{
 	},
 }
 
-//ListRealtimeService permits to display the array of Service return by the API
+// ListRealtimeService permits to display the array of Service return by the API
 func ListRealtimeService(output string, state string, limit int, viewType string, poller int, regex string, debugV bool) error {
 	colorRed := colorMessage.GetColorRed()
 
@@ -89,7 +89,7 @@ func ListRealtimeService(output string, state string, limit int, viewType string
 	case "unhandled":
 		viewTypeSearch = "[\"unhandled_problems\"]"
 	case "all":
-		viewTypeSearch = "[\"all\"]"
+		viewTypeSearch = "[]"
 	}
 
 	//Conversion of the state


### PR DESCRIPTION
Filter "all" doesn't exist anymore in Centreon 23.10
leave the state filter array blank instead