### PR TITLE
Fix listing RealtimeHost with all view + backward compatibility 

### DIFF
--- a/cmd/list/realtimeHost.go
+++ b/cmd/list/realtimeHost.go
@@ -61,7 +61,7 @@ var realtimeHostCmd = &cobra.Command{
 	},
 }
 
-//ListRealtimeHost permits to display the array of realtime information of host return by the API
+// ListRealtimeHost permits to display the array of realtime information of host return by the API
 func ListRealtimeHost(output string, state string, limit int, viewType string, poller int, regex string, debugV bool) error {
 	colorRed := colorMessage.GetColorRed()
 	state = strings.ToLower(state)
@@ -88,7 +88,7 @@ func ListRealtimeHost(output string, state string, limit int, viewType string, p
 	case "unhandled":
 		viewTypeSearch = "[\"unhandled_problems\"]"
 	case "all":
-		viewTypeSearch = "[\"all\"]"
+		viewTypeSearch = "[]"
 	}
 
 	//Conversion of the state

--- a/cmd/list/realtimeHost.go
+++ b/cmd/list/realtimeHost.go
@@ -86,9 +86,9 @@ func ListRealtimeHost(output string, state string, limit int, viewType string, p
 	viewTypeSearch := ""
 	switch viewType {
 	case "unhandled":
-		viewTypeSearch = "[\"unhandled_problems\"]"
+		viewTypeSearch = "&states=[\"unhandled_problems\"]"
 	case "all":
-		viewTypeSearch = "[]"
+		viewTypeSearch = ""
 	}
 
 	//Conversion of the state
@@ -108,7 +108,7 @@ func ListRealtimeHost(output string, state string, limit int, viewType string, p
 	}
 
 	//Recovery of the response body
-	urlCentreon := "/monitoring/resources?limit=" + strconv.Itoa(limit) + "&types=[\"host\"]&statuses=" + stateSearch + "&states=" + viewTypeSearch
+	urlCentreon := "/monitoring/resources?limit=" + strconv.Itoa(limit) + "&types=[\"host\"]&statuses=" + stateSearch + viewTypeSearch
 	err, body := request.GeneriqueCommandV2Get(urlCentreon, "list realtimeHost", debugV)
 	if err != nil {
 		return err

--- a/cmd/list/realtimeService.go
+++ b/cmd/list/realtimeService.go
@@ -87,9 +87,9 @@ func ListRealtimeService(output string, state string, limit int, viewType string
 	viewTypeSearch := ""
 	switch viewType {
 	case "unhandled":
-		viewTypeSearch = "[\"unhandled_problems\"]"
+		viewTypeSearch = "&states=[\"unhandled_problems\"]"
 	case "all":
-		viewTypeSearch = "[]"
+		viewTypeSearch = ""
 	}
 
 	//Conversion of the state
@@ -111,7 +111,7 @@ func ListRealtimeService(output string, state string, limit int, viewType string
 	}
 
 	//Recovery of the response body
-	urlCentreon := "/monitoring/resources?limit=" + strconv.Itoa(limit) + "&types=[\"service\"]&statuses=" + stateSearch + "&states=" + viewTypeSearch
+	urlCentreon := "/monitoring/resources?limit=" + strconv.Itoa(limit) + "&types=[\"service\"]&statuses=" + stateSearch + viewTypeSearch
 	err, body := request.GeneriqueCommandV2Get(urlCentreon, "list realtimeService", debugV)
 	if err != nil {
 		return err


### PR DESCRIPTION
Centreon 22..04 and 22.10 doesn't allow empty states value
So if all filter is used; the state parameter is not put on the request URL
